### PR TITLE
ci: add broken link check workflow

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -27,6 +27,8 @@ jobs:
             --no-progress
             --timeout 30
             --max-retries 3
+            --scheme https
+            --scheme http
             --exclude 'localhost'
             --exclude '127\.0\.0\.1'
             --exclude 'ytnobody\.github\.io/calcium-pages'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,45 @@
+name: Link Check
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  schedule:
+    - cron: "0 9 * * 1" # Every Monday at 9:00 UTC
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check links with lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --verbose
+            --no-progress
+            --timeout 30
+            --max-retries 3
+            --exclude 'localhost'
+            --exclude '127\.0\.0\.1'
+            --exclude 'ytnobody\.github\.io/calcium-pages'
+            --exclude 'example\.com'
+            -- '**/*.md'
+          fail: ${{ github.event_name == 'pull_request' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create issue on broken links (scheduled run)
+        if: github.event_name == 'schedule' && env.lychee_exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "Broken links detected"
+          content-filepath: ./lychee/out.md
+          labels: bug, documentation


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`.github/workflows/link-check.yml`) that uses lychee-action to check for broken links in all markdown files
- Runs on PRs targeting `develop` and `main` branches, and weekly on Monday at 9:00 UTC
- Excludes localhost, 127.0.0.1, the site's own GitHub Pages URL, and example.com from checks
- On scheduled runs, automatically creates an issue if broken links are found

Closes #1

## Test plan
- [ ] Verify workflow triggers on PR to develop
- [ ] Verify lychee finds and reports broken links correctly
- [ ] Verify excluded URL patterns are not checked
- [ ] Verify the workflow fails PR checks when broken links exist
- [ ] Verify issue creation works on scheduled runs with broken links

Generated with [Claude Code](https://claude.com/claude-code)