### PR TITLE
github-3: 検索機能の追加（lunr.js）

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,6 +12,7 @@ header_pages:
   - docs/modules/index.md
   - docs/stdlib/index.md
   - docs/reference/index.md
+  - search.md
 
 # Markdown settings
 markdown: kramdown
@@ -34,3 +35,7 @@ exclude:
   - README.md
   - Gemfile
   - Gemfile.lock
+
+# Include search.json in the build output
+include:
+  - search.json

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,0 +1,104 @@
+(function () {
+  'use strict';
+
+  var searchIndex = null;
+  var searchData = [];
+
+  function initSearch() {
+    var searchInput = document.getElementById('search-input');
+    var searchResults = document.getElementById('search-results');
+
+    if (!searchInput || !searchResults) return;
+
+    fetch(getBaseUrl() + '/search.json')
+      .then(function (response) { return response.json(); })
+      .then(function (data) {
+        searchData = data;
+        searchIndex = lunr(function () {
+          this.field('title', { boost: 10 });
+          this.field('content');
+          this.ref('id');
+
+          data.forEach(function (page) {
+            this.add(page);
+          }, this);
+        });
+
+        searchInput.addEventListener('input', function () {
+          var query = searchInput.value.trim();
+          if (query.length < 2) {
+            searchResults.innerHTML = '';
+            return;
+          }
+          displayResults(query);
+        });
+
+        // Run search if query is already in URL
+        var params = new URLSearchParams(window.location.search);
+        var q = params.get('q');
+        if (q) {
+          searchInput.value = q;
+          displayResults(q);
+        }
+      })
+      .catch(function (err) {
+        searchResults.innerHTML = '<p>検索インデックスの読み込みに失敗しました。</p>';
+        console.error('Search index load error:', err);
+      });
+  }
+
+  function getBaseUrl() {
+    var base = document.querySelector('meta[name="baseurl"]');
+    return base ? base.getAttribute('content') : '';
+  }
+
+  function displayResults(query) {
+    var searchResults = document.getElementById('search-results');
+    var results;
+    try {
+      results = searchIndex.search(query);
+    } catch (e) {
+      results = [];
+    }
+
+    if (results.length === 0) {
+      searchResults.innerHTML = '<p>「' + escapeHtml(query) + '」に一致するページが見つかりませんでした。</p>';
+      return;
+    }
+
+    var html = '<ul class="search-results-list">';
+    results.forEach(function (result) {
+      var page = searchData.find(function (p) { return String(p.id) === result.ref; });
+      if (!page) return;
+      var excerpt = getExcerpt(page.content, query);
+      html += '<li class="search-result-item">';
+      html += '<a href="' + escapeHtml(page.url) + '" class="search-result-title">' + escapeHtml(page.title) + '</a>';
+      html += '<p class="search-result-excerpt">' + escapeHtml(excerpt) + '</p>';
+      html += '</li>';
+    });
+    html += '</ul>';
+    html = '<p>' + results.length + ' 件見つかりました。</p>' + html;
+    searchResults.innerHTML = html;
+  }
+
+  function getExcerpt(content, query) {
+    if (!content) return '';
+    var index = content.toLowerCase().indexOf(query.toLowerCase());
+    if (index === -1) return content.substring(0, 150) + '...';
+    var start = Math.max(0, index - 60);
+    var end = Math.min(content.length, index + query.length + 90);
+    var excerpt = (start > 0 ? '...' : '') + content.substring(start, end) + (end < content.length ? '...' : '');
+    return excerpt;
+  }
+
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  document.addEventListener('DOMContentLoaded', initSearch);
+})();

--- a/search.json
+++ b/search.json
@@ -1,0 +1,16 @@
+---
+layout: none
+---
+[
+  {% assign pages = site.pages | where_exp: "page", "page.title != nil" %}
+  {% for page in pages %}
+    {% unless page.url contains 'search' %}
+    {
+      "id": {{ forloop.index }},
+      "title": {{ page.title | jsonify }},
+      "url": "{{ site.baseurl }}{{ page.url }}",
+      "content": {{ page.content | strip_html | normalize_whitespace | truncate: 5000 | jsonify }}
+    }{% unless forloop.last %},{% endunless %}
+    {% endunless %}
+  {% endfor %}
+]

--- a/search.md
+++ b/search.md
@@ -1,0 +1,65 @@
+---
+layout: page
+title: 検索
+permalink: /search/
+---
+
+<meta name="baseurl" content="{{ site.baseurl }}">
+
+<div class="search-container">
+  <input
+    type="search"
+    id="search-input"
+    class="search-input"
+    placeholder="キーワードを入力..."
+    aria-label="サイト内検索"
+    autocomplete="off"
+  >
+</div>
+
+<div id="search-results"></div>
+
+<script src="https://unpkg.com/lunr/lunr.js"></script>
+<script src="{{ site.baseurl }}/assets/js/search.js"></script>
+
+<style>
+.search-container {
+  margin: 1.5em 0;
+}
+
+.search-input {
+  width: 100%;
+  padding: 0.6em 0.8em;
+  font-size: 1em;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+.search-results-list {
+  list-style: none;
+  padding: 0;
+  margin: 1em 0;
+}
+
+.search-result-item {
+  border-bottom: 1px solid #eee;
+  padding: 1em 0;
+}
+
+.search-result-title {
+  font-size: 1.1em;
+  font-weight: bold;
+  text-decoration: none;
+}
+
+.search-result-title:hover {
+  text-decoration: underline;
+}
+
+.search-result-excerpt {
+  color: #555;
+  font-size: 0.9em;
+  margin: 0.3em 0 0;
+}
+</style>


### PR DESCRIPTION
Issue: github-3

## 変更内容

lunr.js を使ったクライアントサイド検索機能を追加しました。

## 実装詳細

- **search.json**: Jekyll の Liquid テンプレートで全ページのタイトル・本文を含む検索インデックスを自動生成
- **search.md**: 検索UIページ。lunr.js を CDN から読み込み、リアルタイム検索を実現
- **assets/js/search.js**: 検索ロジック本体（インデックス構築・クエリ実行・結果表示）
- **_config.yml**: ヘッダーナビゲーションに「検索」ページを追加

## 動作概要

1. ページ読み込み時に `search.json` を fetch してインデックスを構築
2. 入力フィールドへのタイピングに応じてリアルタイムで検索実行
3. 検索結果にはページタイトルとコンテンツの抜粋を表示
4. URLクエリパラメータ `?q=xxx` でも検索可能